### PR TITLE
Small Animals Ped Check

### DIFF
--- a/vorp_hunting/client/main.lua
+++ b/vorp_hunting/client/main.lua
@@ -262,16 +262,15 @@ Citizen.CreateThread(function()
                     local ped = view['0']
 					local model = GetEntityModel(pedGathered)
 
-                    -- Potential fix; however just a theory and still needs to be tested.
-                    -- NOT TESTED YET
+                    -- Ensure the player who enacted the event is the one who gets the rewards
                     local player = PlayerPedId()
                     local playergate = player == ped
 
-                    print('Animal Gathered: ' ..model)
-                    -- print('Player Gated:', playergate)
+                    -- print('Correct Player:', playergate)
 					
                     if model and Config.SmallAnimals[model] ~= nil and playergate == true then
-						local smallAnimal = Config.SmallAnimals[model]
+                        print('Animal Gathered: ' ..model)
+                        local smallAnimal = Config.SmallAnimals[model]
                         local givenItem = smallAnimal.givenItem
                         local givenAmount = smallAnimal.givenAmount
                         local money = smallAnimal.money

--- a/vorp_hunting/client/main.lua
+++ b/vorp_hunting/client/main.lua
@@ -259,11 +259,18 @@ Citizen.CreateThread(function()
 				if event == 1376140891 then
 					local view = exports["vorp_hunting"]:DataViewNativeGetEventData(0, index, 3)
 					local pedGathered = view['2']
+                    local ped = view['0']
 					local model = GetEntityModel(pedGathered)
-					
+
+                    -- Potential fix; however just a theory and still needs to be tested.
+                    -- NOT TESTED YET
+                    local player = PlayerPedId()
+                    local playergate = player == ped
+
                     print('Animal Gathered: ' ..model)
+                    -- print('Player Gated:', playergate)
 					
-                    if model and Config.SmallAnimals[model] ~= nil then
+                    if model and Config.SmallAnimals[model] ~= nil and playergate == true then
 						local smallAnimal = Config.SmallAnimals[model]
                         local givenItem = smallAnimal.givenItem
                         local givenAmount = smallAnimal.givenAmount


### PR DESCRIPTION
I think the issue may be that each client is rewarding any ped event action, meaning other players as well. 

I have not tested this theory yet, or this code as it is getting late. But will test asap and get a more official PR up.

_Raising draft PR for visibility._

[Edit]
Confirmed: The event call was enacted for all players. 
Example Issue: Player 1 triggers a skinning event, all other players also receive this event nearby
Solution: I added a ped check to ensure the ped who enacted the event is the ped who gets the reward.