### PR TITLE
Adding fix for exploit

### DIFF
--- a/vorp_hunting/client/main.lua
+++ b/vorp_hunting/client/main.lua
@@ -261,14 +261,15 @@ Citizen.CreateThread(function()
 					local pedGathered = view['2']
                     local ped = view['0']
 					local model = GetEntityModel(pedGathered)
+                    
+                    -- Bool to let you know if animation/longpress was enacted.
+                    local bool_unk = view['4']
 
                     -- Ensure the player who enacted the event is the one who gets the rewards
                     local player = PlayerPedId()
                     local playergate = player == ped
-
-                    -- print('Correct Player:', playergate)
 					
-                    if model and Config.SmallAnimals[model] ~= nil and playergate == true then
+                    if model and Config.SmallAnimals[model] ~= nil and playergate == true and bool_unk == 1  then
                         print('Animal Gathered: ' ..model)
                         local smallAnimal = Config.SmallAnimals[model]
                         local givenItem = smallAnimal.givenItem


### PR DESCRIPTION
I didn't realize there is a Boolean variable that states if it has been long-press enacted or not. I have tested this on Raccoon, Rat, and Deer and it seems to resolve the main issue brought up in [issues #18](https://github.com/VORPCORE/VORP-Hunting/issues/18)