### PR TITLE
new feature: givenItem-specific random ranges for givenAmount

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -57,7 +57,7 @@ Config.Butchers = {
 -----------------ANIMAL INSTRUCTIONS  -----------------
 -- 1. To add more rewards on each animal, edit the givenItem table. For example change givenItem ={ "meat"}, to givenItem ={ "meat","feathers"}
 -- 2. If using more than one item in givenItem, then you must add another value to givenAmount. For example change givenAmount ={0}, to givenAmount ={0,0}
--- 3. givenAmount = {0} will set a amount to random amount between ItemQuantity Max/Min
+-- 3. givenAmount = {0} will set an amount to random amount between ItemQuantity Max/Min
 -- 4. givenAmount = {{2,5}} will set an amount to random between the first and second numbers in the supplied table, for the corresponding givenItem.
 -- For example: givenItem = {"meat", "feathers", "claws", "beak"}, givenAmount = {{1,4}, {2,5}, 0, 1} will result in 1 to 4 "meat", 2 to 5 "feathers", ItemQuantity.Min to ItemQuanity.Max "claws" and 1 "beak".
 

--- a/config.lua
+++ b/config.lua
@@ -56,8 +56,10 @@ Config.Butchers = {
 
 -----------------ANIMAL INSTRUCTIONS  -----------------
 -- 1. To add more rewards on each animal, edit the givenItem table. For example change givenItem ={ "meat"}, to givenItem ={ "meat","feathers"}
--- 2. If using more than one item in givenItem, then you must add another value to giveAmount. For example change givenAmount ={0}, to givenAmount ={0,0}
--- 3. giveAmount = {0} will set a amount to random amount between ItemQuantity max/min
+-- 2. If using more than one item in givenItem, then you must add another value to givenAmount. For example change givenAmount ={0}, to givenAmount ={0,0}
+-- 3. givenAmount = {0} will set a amount to random amount between ItemQuantity Max/Min
+-- 4. givenAmount = {{2,5}} will set an amount to random between the first and second numbers in the supplied table, for the corresponding givenItem.
+-- For example: givenItem = {"meat", "feathers", "claws", "beak"}, givenAmount = {{1,4}, {2,5}, 0, 1} will resuilt in 1 to 4 "meat", 2 to 5 "feathers", ItemQuantity.Min to ItemQuanity.Max "claws" and 1 "beak".
 
 ----------------- !IMPORTANT! -----------------
 -- TO ADD MORE ANIMALS AND FIND HASHES, HOLD ANIMALS OR PELTS AND DO /ANIMAL command

--- a/config.lua
+++ b/config.lua
@@ -59,7 +59,7 @@ Config.Butchers = {
 -- 2. If using more than one item in givenItem, then you must add another value to givenAmount. For example change givenAmount ={0}, to givenAmount ={0,0}
 -- 3. givenAmount = {0} will set a amount to random amount between ItemQuantity Max/Min
 -- 4. givenAmount = {{2,5}} will set an amount to random between the first and second numbers in the supplied table, for the corresponding givenItem.
--- For example: givenItem = {"meat", "feathers", "claws", "beak"}, givenAmount = {{1,4}, {2,5}, 0, 1} will resuilt in 1 to 4 "meat", 2 to 5 "feathers", ItemQuantity.Min to ItemQuanity.Max "claws" and 1 "beak".
+-- For example: givenItem = {"meat", "feathers", "claws", "beak"}, givenAmount = {{1,4}, {2,5}, 0, 1} will result in 1 to 4 "meat", 2 to 5 "feathers", ItemQuantity.Min to ItemQuanity.Max "claws" and 1 "beak".
 
 ----------------- !IMPORTANT! -----------------
 -- TO ADD MORE ANIMALS AND FIND HASHES, HOLD ANIMALS OR PELTS AND DO /ANIMAL command

--- a/server/main.lua
+++ b/server/main.lua
@@ -104,13 +104,17 @@ local function giveReward(context, data, skipfinal)
 			-- Format items and set random quantities if set.
 			-- Check if items can be added
 			-- total up the quantity so it can be checked as a whole
-			for k, v in pairs(givenItem) do
+			for k, v in ipairs(givenItem) do
 				local nmb = 0
-
-				if givenAmount[k] > 0 then
-					nmb = givenAmount[k]
+				
+				if type(givenAmount[k]) == "table" then
+					nbm = math.random(tonumber(givenAmount[k][1]) or 0, tonumber(givenAmount[k][2]) or 1)
 				else
-					nmb = math.random(Config.ItemQuantity.Min, Config.ItemQuantity.Max)
+					if givenAmount[k] > 0 then
+						nmb = givenAmount[k]
+					else
+						nmb = math.random(Config.ItemQuantity.Min, Config.ItemQuantity.Max)
+					end
 				end
 
 				formattedGivenItems[k] = {


### PR DESCRIPTION
Example usage in config.lua:

Config.Animals = {
    [-1143398950]  = { name = "Big Grey Wolf", givenItem = { "meat", "wolf_fang", "wolf_heart" }, givenAmount = { {2,5}, {1,2}, 1 }, money = 3, gold = 0, rolPoints = 0, xp = 3, poorQualityMultiplier = 1.0, goodQualityMultiplier = 1.5, perfectQualityMultiplier = 2, poor = 85441452, good = 1145777975, perfect = 653400939 },
}

The above example would make it so Big Grey Wolf carcasses give a random amount of "meat" between 2 and 5 and a random amount of "wolf_fang" between 1 and 2, and a guaranteed 1 "wolf_heart" when sold at a butcher.