### PR TITLE
Limit pelts on horses to 3 max

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -199,12 +199,16 @@ Citizen.CreateThread(function()
             if 2 > dist then
                 local model = GetEntityModel(holding)
                 if holding ~= false and Config.Animals[model] == nil then
-                    if Config.maxpelts > Keys(peltz) then
 
+                    local maxpelts = Config.maxpelts
+                    if Config.maxpelts > 3 then --Limit max pelts to 3 as thats what red dead allows on a horse
+                        maxpelts = 3
+                    end
+
+                    if maxpelts > Keys(peltz) then
                         local label = CreateVarString(10, 'LITERAL_STRING', Config.Language.stow)
                         PromptSetActiveGroupThisFrame(prompts, label)
                         if Citizen.InvokeNative(0xC92AC953F0A982AE, openButcher) then
-
                             TaskPlaceCarriedEntityOnMount(player, holding, horse, 1)
                             table.insert(peltz, {
                                 holding = holding,

--- a/config.lua
+++ b/config.lua
@@ -33,7 +33,7 @@ Config.aiButcherped = true -- spawn ai butched ped set to false if you dont want
 
 Config.joblocked = false -- lock the butcher so only people with the job can access. u can change access to each butcher by editing this  butcherjob = "butcher"
 
-Config.maxpelts = 2 -- max pelts allowed on back of horse
+Config.maxpelts = 2 -- max pelts allowed on back of horse (Max 3 allowed)
 
 ------------------- Item Quantity Instructions -----------------
 -- The range for when a skinnableAnimal or Animal has a config value givenAmount of 0.


### PR DESCRIPTION
RDO and RDR2 both limit pelt storage on horses to 3 pelts. I believe this is what is happening in this issue [Issue 47](https://github.com/VORPCORE/VORP-Hunting/issues/47)

In order to resolve this immediately, `Config.maxpelts` is now limited to 3 pelts max.